### PR TITLE
ユーザーAPIのユースケース層

### DIFF
--- a/backend/src/domain/User/User.ts
+++ b/backend/src/domain/User/User.ts
@@ -5,15 +5,25 @@ import { IUser } from "@/models/UserModel";
 export class User {
   private username: string;
   private password: string;
-  private userId: string = this.generateUserId();
-  private sumScore: number = 0;
-  private fishingRodLevel: number = 1;
+  private userId: string;
+  private sumScore: number;
+  private fishingRodLevel: number;
   private caughtFish: {
     name: string;
     count: number;
-  }[] = [];
+  }[];
 
-  constructor(username: string, password: string) {
+  constructor(
+    username: string,
+    password: string,
+    userId: string = this.generateUserId(),
+    sumScore: number = 0,
+    fishingRodLevel: number = 1,
+    caughtFish: {
+      name: string;
+      count: number;
+    }[] = []
+  ) {
     if (username.length < 3 || username.length > 256) {
       throw new Error("ユーザー名は3文字以上256文字以内である必要があります");
     }
@@ -22,6 +32,10 @@ export class User {
     }
     this.username = username;
     this.password = this.hashPasswordSync(password);
+    this.userId = userId;
+    this.sumScore = sumScore;
+    this.fishingRodLevel = fishingRodLevel;
+    this.caughtFish = caughtFish;
   }
 
   // ユーザーIDを生成
@@ -35,11 +49,15 @@ export class User {
     const saltRounds = 10;
     return bcrypt.hashSync(password, saltRounds);
   }
-
   // パスワードの照合メソッド
   public async comparePassword(inputPassword: string): Promise<boolean> {
     const isMatch = await bcrypt.compare(inputPassword, this.password);
     return isMatch;
+  }
+  // スコアを加算
+  public addScore(score: number): number {
+    this.sumScore += score;
+    return this.sumScore;
   }
   // 釣竿レベル更新のためのバリデーションチェック（返り値は更新後のレベルと必要なスコア）
   public validateFishingRodLevelUpgrade(
@@ -55,6 +73,13 @@ export class User {
       default:
         throw new Error("無効な入力です");
     }
+  }
+  // 釣竿レベルを比較するメソッド
+  public isBigInputFishingRodLevel(inputLevel: number): number | Error {
+    if (inputLevel <= this.fishingRodLevel) {
+      throw new Error("入力された釣竿レベルは現在の釣竿レベル以下です");
+    }
+    return inputLevel;
   }
   // 魚名のバリデーションチェック
   public validateFishName = (name: string): string | Error => {

--- a/backend/src/usecase/User/AddSumScoreUseCase.ts
+++ b/backend/src/usecase/User/AddSumScoreUseCase.ts
@@ -1,0 +1,34 @@
+import { IUserRepository } from "@/src/domain/User/User";
+import { User } from "@/src/domain/User/User";
+
+interface AddSumScoreInput {
+  userId: string;
+  additionalScore: number;
+}
+
+export class AddSumScoreUseCase {
+  private userRepository: IUserRepository;
+
+  constructor(userRepository: IUserRepository) {
+    this.userRepository = userRepository;
+  }
+
+  public async execute(input: AddSumScoreInput): Promise<number> {
+    const { userId, additionalScore } = input;
+    const user = await this.userRepository.getUserById(userId);
+    if (!user) {
+      throw new Error(`ユーザーID ${userId} が見つかりません`);
+    }
+    const newUser = new User(
+      user.username,
+      user.password,
+      undefined,
+      user.sumScore
+    );
+    const updateSumScore = newUser.addScore(additionalScore);
+    return await this.userRepository.updateSumScore(
+      user.userId,
+      updateSumScore
+    );
+  }
+}

--- a/backend/src/usecase/User/GetUserDataUseCase.ts
+++ b/backend/src/usecase/User/GetUserDataUseCase.ts
@@ -1,0 +1,25 @@
+import { IUserRepository } from "@/src/domain/User/User";
+import { IUser } from "@/models/UserModel";
+
+interface GetUserDataInput {
+  userId: string;
+}
+
+export class GetUserDataUseCase {
+  private userRepository: IUserRepository;
+
+  constructor(userRepository: IUserRepository) {
+    this.userRepository = userRepository;
+  }
+
+  public async execute(input: GetUserDataInput): Promise<IUser> {
+    const { userId } = input;
+    const user = await this.userRepository.getUserById(userId);
+    if (!user) {
+      throw new Error(
+        `ユーザーID "${userId}" に該当するユーザーが見つかりません。`
+      );
+    }
+    return user;
+  }
+}

--- a/backend/src/usecase/User/IncrementCaughtFishCountUseCase.ts
+++ b/backend/src/usecase/User/IncrementCaughtFishCountUseCase.ts
@@ -1,0 +1,37 @@
+import { IUserRepository } from "@/src/domain/User/User";
+import { User } from "@/src/domain/User/User";
+
+interface IncrementCaughtFishCountInput {
+  userId: string;
+  name: string;
+}
+
+export class IncrementCaughtFishCountUseCase {
+  private userRepository: IUserRepository;
+
+  constructor(userRepository: IUserRepository) {
+    this.userRepository = userRepository;
+  }
+
+  public async execute(input: IncrementCaughtFishCountInput): Promise<
+    {
+      name: string;
+      count: number;
+    }[]
+  > {
+    const { userId, name } = input;
+    const user = await this.userRepository.getUserById(userId);
+    if (!user) {
+      throw new Error(`ユーザーID ${userId} が見つかりません`);
+    }
+    const newUser = new User(user.username, user.password);
+    const validateName = newUser.validateFishName(name);
+    if (validateName instanceof Error) {
+      throw validateName;
+    }
+    return await this.userRepository.incrementCaughtFishCount(
+      user.userId,
+      validateName
+    );
+  }
+}

--- a/backend/src/usecase/User/RegisterUserUseCase.ts
+++ b/backend/src/usecase/User/RegisterUserUseCase.ts
@@ -1,0 +1,33 @@
+import { User } from "@/src/domain/User/User";
+import { IUserRepository } from "@/src/domain/User/User";
+
+interface RegisterUserInput {
+  username: string;
+  password: string;
+}
+interface RegisterUserOutput {
+  username: string;
+  userId: string;
+}
+
+export class ResisterUserUseCase {
+  private userRepository: IUserRepository;
+
+  constructor(userRepository: IUserRepository) {
+    this.userRepository = userRepository;
+  }
+
+  public async execute(input: RegisterUserInput): Promise<RegisterUserOutput> {
+    const { username, password } = input;
+    const newUser = new User(username, password);
+    const savedUser = await this.userRepository.authUser(
+      newUser.getUser().username,
+      newUser.getUser().userId,
+      newUser.getUser().password
+    );
+    return {
+      username: savedUser.username,
+      userId: savedUser.userId,
+    };
+  }
+}

--- a/backend/src/usecase/User/UpdateFishingRodLevelUseCase.ts
+++ b/backend/src/usecase/User/UpdateFishingRodLevelUseCase.ts
@@ -1,0 +1,48 @@
+import { IUserRepository } from "@/src/domain/User/User";
+import { User } from "@/src/domain/User/User";
+
+interface UpdateFishingRodLevelInput {
+  userId: string;
+  fishingRodLevel: number;
+}
+
+export class UpdateFishingRodLevelUseCase {
+  private userRepository: IUserRepository;
+
+  constructor(userRepository: IUserRepository) {
+    this.userRepository = userRepository;
+  }
+
+  public async execute(input: UpdateFishingRodLevelInput): Promise<number> {
+    const { userId, fishingRodLevel } = input;
+    const user = await this.userRepository.getUserById(userId);
+    if (!user) {
+      throw new Error(`ユーザーID ${userId} が見つかりません`);
+    }
+
+    const newUser = new User(
+      user.username,
+      user.password,
+      undefined,
+      0,
+      user.fishingRodLevel
+    );
+    const updatableFishingRodLevel =
+      newUser.isBigInputFishingRodLevel(fishingRodLevel);
+    if (updatableFishingRodLevel instanceof Error) {
+      throw updatableFishingRodLevel;
+    }
+    const validateFishingRodLevel = newUser.validateFishingRodLevelUpgrade(
+      updatableFishingRodLevel
+    );
+    if (validateFishingRodLevel instanceof Error) {
+      throw validateFishingRodLevel;
+    }
+    const [updatedLevel, requiredScore] = validateFishingRodLevel;
+    return await this.userRepository.updateFishingRodLevel(
+      user.userId,
+      updatedLevel,
+      requiredScore
+    );
+  }
+}


### PR DESCRIPTION
## 内容

■ ドメイン層の改善
　・値の初期化をコンストラクタ内で行うように修正しました
　・釣竿レベルを比較する処理とスコアを加算する処理を追加しました

■ ドメイン層から、それぞれの処理のユースケース層を実装しました
　・スコアを加算するユースケース層を実装しました
　・ユーザー情報を取得するユースケース層を実装しました
　・捕まえた魚をカウントするユースケース層を実装しました
　・ユーザーを新規登録するユースケース層を実装しました
　・釣竿レベルを更新するユースケース層を実装しました