### PR TITLE
ユーザーAPIのプレゼンテーション層

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -5,12 +5,40 @@ import cors from "cors";
 import helmet from "helmet";
 import connectDB from "@/src/infrastructure/db/mongoConnection";
 
+import { UserRepository } from "@/src/infrastructure/User/UserRepository";
+import { AddSumScoreController } from "@/src/presentation/User/AddSumScoreController";
+import { GetUserDataController } from "@/src/presentation/User/GetUserDataController";
+import { IncrementCaughtFishCountController } from "@/src/presentation/User/IncrementCaughtFishCountController";
+import { RegisterUserController } from "@/src/presentation/User/RegisterUserController";
+import { UpdateFishingRodLevelController } from "@/src/presentation/User/UpdateFishingRodLevelController";
+import { IUserRepository } from "./src/domain/User/User";
+
 const app = express();
 const port = process.env.PORT || 3000;
 
 app.use(cors());
 app.use(helmet());
 app.use(express.json());
+
+// インフラ層のリポジトリをインスタンス化
+const userRepository: IUserRepository = new UserRepository();
+
+// プレゼンテーション層のコントローラをインスタンス化
+const addSumScoreController = new AddSumScoreController(userRepository);
+const getUserDataController = new GetUserDataController(userRepository);
+const incrementCaughtFishCountController =
+  new IncrementCaughtFishCountController(userRepository);
+const registerUserController = new RegisterUserController(userRepository);
+const updateFishingRodLevelController = new UpdateFishingRodLevelController(
+  userRepository
+);
+
+// エンドポイントを登録
+addSumScoreController.addSumScore(app);
+getUserDataController.getUserData(app);
+incrementCaughtFishCountController.incrementCaughtFishCount(app);
+registerUserController.registerUser(app);
+updateFishingRodLevelController.updateFishingRodLevel(app);
 
 connectDB()
   .then(() => {

--- a/backend/src/domain/User/User.ts
+++ b/backend/src/domain/User/User.ts
@@ -14,8 +14,8 @@ export class User {
   }[];
 
   constructor(
-    username: string,
-    password: string,
+    username: string = "xxx",
+    password: string = "xxxxxx",
     userId: string = this.generateUserId(),
     sumScore: number = 0,
     fishingRodLevel: number = 1,
@@ -124,7 +124,13 @@ export interface IUserRepository {
   authUser(
     username: string,
     userId: string,
-    password: string
+    password: string,
+    sumScore: number,
+    fishingRodLevel: number,
+    caughtFish: {
+      name: string;
+      count: number;
+    }[]
   ): Promise<{ username: string; userId: string }>;
 
   /**

--- a/backend/src/infrastructure/User/UserRepository.ts
+++ b/backend/src/infrastructure/User/UserRepository.ts
@@ -5,19 +5,38 @@ export class UserRepository {
   public authUser = async (
     username: string,
     userId: string,
-    password: string
-  ): Promise<{ username: string; userId: string }> => {
+    password: string,
+    sumScore: number,
+    fishingRodLevel: number,
+    caughtFish: {
+      name: string;
+      count: number;
+    }[]
+  ): Promise<{
+    username: string;
+    userId: string;
+    fishingRodLevel: number;
+    caughtFish: {
+      name: string;
+      count: number;
+    }[];
+  }> => {
     try {
       const newUser = new UserModel({
         username,
         password,
         userId,
+        sumScore,
+        fishingRodLevel,
+        caughtFish,
       });
       const savedUser = await newUser.save();
 
       return {
         username: savedUser.username,
         userId: savedUser.userId,
+        fishingRodLevel: savedUser.fishingRodLevel,
+        caughtFish: savedUser.caughtFish,
       };
     } catch (err) {
       console.error("ユーザー作成エラー:", err);
@@ -81,7 +100,7 @@ export class UserRepository {
         throw new Error("ユーザーが見つかりません");
       }
 
-      user.sumScore += additionalScore;
+      user.sumScore = additionalScore;
       await user.save();
       console.log(`ユーザー ${userId} の sumScore を更新しました`);
 

--- a/backend/src/presentation/User/AddSumScoreController.ts
+++ b/backend/src/presentation/User/AddSumScoreController.ts
@@ -1,0 +1,27 @@
+import { Router, Request, Response } from "express";
+import { AddSumScoreUseCase } from "@/src/usecase/User/AddSumScoreUseCase";
+import { IUserRepository } from "@/src/domain/User/User";
+
+export class AddSumScoreController {
+  private addSumScoreUseCase: AddSumScoreUseCase;
+
+  constructor(userRepository: IUserRepository) {
+    this.addSumScoreUseCase = new AddSumScoreUseCase(userRepository);
+  }
+
+  public addSumScore(router: Router) {
+    router.post("/add-score/:userId", async (req: Request, res: Response) => {
+      try {
+        const { userId } = req.params;
+        const { additionalScore } = req.body;
+        const result = await this.addSumScoreUseCase.execute({
+          userId,
+          additionalScore,
+        });
+        res.status(200).json(result);
+      } catch (error: any) {
+        res.status(400).json({ message: error.message });
+      }
+    });
+  }
+}

--- a/backend/src/presentation/User/GetUserDataController.ts
+++ b/backend/src/presentation/User/GetUserDataController.ts
@@ -1,0 +1,23 @@
+import { Router, Request, Response } from "express";
+import { GetUserDataUseCase } from "@/src/usecase/User/GetUserDataUseCase";
+import { IUserRepository } from "@/src/domain/User/User";
+
+export class GetUserDataController {
+  private getUserDataUseCase: GetUserDataUseCase;
+
+  constructor(userRepository: IUserRepository) {
+    this.getUserDataUseCase = new GetUserDataUseCase(userRepository);
+  }
+
+  public getUserData(router: Router) {
+    router.get("/user-data/:userId", async (req: Request, res: Response) => {
+      try {
+        const { userId } = req.params;
+        const result = await this.getUserDataUseCase.execute({ userId });
+        res.status(200).json(result);
+      } catch (error: any) {
+        res.status(400).json({ message: error.message });
+      }
+    });
+  }
+}

--- a/backend/src/presentation/User/IncrementCaughtFishCountController.ts
+++ b/backend/src/presentation/User/IncrementCaughtFishCountController.ts
@@ -1,0 +1,29 @@
+import { Router, Request, Response } from "express";
+import { IncrementCaughtFishCountUseCase } from "@/src/usecase/User/IncrementCaughtFishCountUseCase";
+import { IUserRepository } from "@/src/domain/User/User";
+
+export class IncrementCaughtFishCountController {
+  private incrementCaughtFishCountUseCase: IncrementCaughtFishCountUseCase;
+
+  constructor(userRepository: IUserRepository) {
+    this.incrementCaughtFishCountUseCase = new IncrementCaughtFishCountUseCase(
+      userRepository
+    );
+  }
+
+  public incrementCaughtFishCount(router: Router) {
+    router.post("/caught-fish/:userId", async (req: Request, res: Response) => {
+      try {
+        const { userId } = req.params;
+        const { name } = req.body;
+        const result = await this.incrementCaughtFishCountUseCase.execute({
+          userId,
+          name,
+        });
+        res.status(200).json(result);
+      } catch (error: any) {
+        res.status(400).json({ message: error.message });
+      }
+    });
+  }
+}

--- a/backend/src/presentation/User/RegisterUserController.ts
+++ b/backend/src/presentation/User/RegisterUserController.ts
@@ -1,0 +1,26 @@
+import { Router, Request, Response } from "express";
+import { RegisterUserUseCase } from "@/src/usecase/User/RegisterUserUseCase";
+import { IUserRepository } from "@/src/domain/User/User";
+
+export class RegisterUserController {
+  private registerUserUseCase: RegisterUserUseCase;
+
+  constructor(userRepository: IUserRepository) {
+    this.registerUserUseCase = new RegisterUserUseCase(userRepository);
+  }
+
+  public registerUser(router: Router) {
+    router.post("/register-user", async (req: Request, res: Response) => {
+      try {
+        const { username, password } = req.body;
+        const result = await this.registerUserUseCase.execute({
+          username,
+          password,
+        });
+        res.status(200).json(result);
+      } catch (error: any) {
+        res.status(400).json({ message: error.message });
+      }
+    });
+  }
+}

--- a/backend/src/presentation/User/UpdateFishingRodLevelController.ts
+++ b/backend/src/presentation/User/UpdateFishingRodLevelController.ts
@@ -1,0 +1,29 @@
+import { Router, Request, Response } from "express";
+import { UpdateFishingRodLevelUseCase } from "@/src/usecase/User/UpdateFishingRodLevelUseCase";
+import { IUserRepository } from "@/src/domain/User/User";
+
+export class UpdateFishingRodLevelController {
+  private updateFishingRodLevelUseCase: UpdateFishingRodLevelUseCase;
+
+  constructor(userRepository: IUserRepository) {
+    this.updateFishingRodLevelUseCase = new UpdateFishingRodLevelUseCase(
+      userRepository
+    );
+  }
+
+  public updateFishingRodLevel(router: Router) {
+    router.post("/update-rod/:userId", async (req: Request, res: Response) => {
+      try {
+        const { userId } = req.params;
+        const { fishingRodLevel } = req.body;
+        const result = await this.updateFishingRodLevelUseCase.execute({
+          userId,
+          fishingRodLevel,
+        });
+        res.status(200).json(result);
+      } catch (error: any) {
+        res.status(400).json({ message: error.message });
+      }
+    });
+  }
+}

--- a/backend/src/usecase/User/AddSumScoreUseCase.ts
+++ b/backend/src/usecase/User/AddSumScoreUseCase.ts
@@ -20,10 +20,12 @@ export class AddSumScoreUseCase {
       throw new Error(`ユーザーID ${userId} が見つかりません`);
     }
     const newUser = new User(
-      user.username,
-      user.password,
-      undefined,
-      user.sumScore
+      undefined, // ユーザー名
+      undefined, // ユーザーID
+      undefined, // パスワード
+      user.sumScore,
+      undefined, // 釣竿レベル
+      undefined // 捕まえた魚リスト
     );
     const updateSumScore = newUser.addScore(additionalScore);
     return await this.userRepository.updateSumScore(

--- a/backend/src/usecase/User/IncrementCaughtFishCountUseCase.ts
+++ b/backend/src/usecase/User/IncrementCaughtFishCountUseCase.ts
@@ -24,7 +24,7 @@ export class IncrementCaughtFishCountUseCase {
     if (!user) {
       throw new Error(`ユーザーID ${userId} が見つかりません`);
     }
-    const newUser = new User(user.username, user.password);
+    const newUser = new User();
     const validateName = newUser.validateFishName(name);
     if (validateName instanceof Error) {
       throw validateName;

--- a/backend/src/usecase/User/RegisterUserUseCase.ts
+++ b/backend/src/usecase/User/RegisterUserUseCase.ts
@@ -10,7 +10,7 @@ interface RegisterUserOutput {
   userId: string;
 }
 
-export class ResisterUserUseCase {
+export class RegisterUserUseCase {
   private userRepository: IUserRepository;
 
   constructor(userRepository: IUserRepository) {
@@ -23,7 +23,10 @@ export class ResisterUserUseCase {
     const savedUser = await this.userRepository.authUser(
       newUser.getUser().username,
       newUser.getUser().userId,
-      newUser.getUser().password
+      newUser.getUser().password,
+      newUser.getUser().sumScore,
+      newUser.getUser().fishingRodLevel,
+      newUser.getUser().caughtFish
     );
     return {
       username: savedUser.username,

--- a/backend/src/usecase/User/UpdateFishingRodLevelUseCase.ts
+++ b/backend/src/usecase/User/UpdateFishingRodLevelUseCase.ts
@@ -21,11 +21,12 @@ export class UpdateFishingRodLevelUseCase {
     }
 
     const newUser = new User(
-      user.username,
-      user.password,
-      undefined,
-      0,
-      user.fishingRodLevel
+      undefined, // ユーザー名
+      undefined, // ユーザーID
+      undefined, // パスワード
+      undefined, // 合計スコア
+      user.fishingRodLevel,
+      undefined // 捕まえた魚
     );
     const updatableFishingRodLevel =
       newUser.isBigInputFishingRodLevel(fishingRodLevel);


### PR DESCRIPTION
## 内容

■ index.tsに各APIのエンドポイントを登録しました
■ ユーザー登録の際に、全てのユーザー情報が登録されるように変更しました
■ 各APIのプレゼンテーション層を実装しました

## 動作確認

■ 総スコアを増やすAPIが動作することを確認しました
■ ユーザー情報取得APIが動作することを確認しました
■ 捕まえた魚を増やすAPIが動作することを確認しました
　・リストに存在しない魚の名前ではエラーメッセージを返すことを確認しました
■ ユーザー登録APIが動作することを確認しました
■ 釣竿レベルをグレードアップするAPIが動作することを確認しました
　・グレードアップのために必要なスコアが足りていない場合や現在の釣竿レベル以下のレベルに更新しようとした場合にエラーメッセージが表示されることを確認しました