### PR TITLE
ユーザーAPI全体の修正

### DIFF
--- a/backend/models/UserModel.ts
+++ b/backend/models/UserModel.ts
@@ -10,6 +10,10 @@ export interface IUser extends Document {
     name: string;
     count: number;
   }[];
+  achievements: {
+    name: string;
+    achieved: boolean;
+  }[];
 }
 
 const UserSchema: Schema<IUser> = new mongoose.Schema(
@@ -47,6 +51,14 @@ const UserSchema: Schema<IUser> = new mongoose.Schema(
         {
           name: { type: String, required: true },
           count: { type: Number, required: true },
+        },
+      ],
+    },
+    achievements: {
+      type: [
+        {
+          name: { type: String, required: true },
+          achieved: { type: Boolean, required: true, default: false },
         },
       ],
     },

--- a/backend/src/domain/User/User.ts
+++ b/backend/src/domain/User/User.ts
@@ -12,6 +12,10 @@ export class User {
     name: string;
     count: number;
   }[];
+  private achievements: {
+    name: string;
+    achieved: boolean;
+  }[];
 
   constructor(
     username: string = "xxx",
@@ -22,6 +26,10 @@ export class User {
     caughtFish: {
       name: string;
       count: number;
+    }[] = [],
+    achievements: {
+      name: string;
+      achieved: boolean;
     }[] = []
   ) {
     if (username.length < 3 || username.length > 256) {
@@ -36,6 +44,7 @@ export class User {
     this.sumScore = sumScore;
     this.fishingRodLevel = fishingRodLevel;
     this.caughtFish = caughtFish;
+    this.achievements = achievements;
   }
 
   // ユーザーIDを生成
@@ -99,6 +108,10 @@ export class User {
     sumScore: number;
     fishingRodLevel: number;
     caughtFish: { name: string; count: number }[];
+    achievements: {
+      name: string;
+      achieved: boolean;
+    }[];
   } {
     return {
       username: this.username,
@@ -107,6 +120,7 @@ export class User {
       sumScore: this.sumScore,
       fishingRodLevel: this.fishingRodLevel,
       caughtFish: this.caughtFish,
+      achievements: this.achievements,
     };
   }
 }
@@ -130,6 +144,10 @@ export interface IUserRepository {
     caughtFish: {
       name: string;
       count: number;
+    }[],
+    achievements: {
+      name: string;
+      achieved: boolean;
     }[]
   ): Promise<{ username: string; userId: string }>;
 

--- a/backend/src/infrastructure/User/UserRepository.ts
+++ b/backend/src/infrastructure/User/UserRepository.ts
@@ -11,6 +11,10 @@ export class UserRepository {
     caughtFish: {
       name: string;
       count: number;
+    }[],
+    achievements: {
+      name: string;
+      achieved: boolean;
     }[]
   ): Promise<{
     username: string;
@@ -19,6 +23,10 @@ export class UserRepository {
     caughtFish: {
       name: string;
       count: number;
+    }[];
+    achievements: {
+      name: string;
+      achieved: boolean;
     }[];
   }> => {
     try {
@@ -29,6 +37,7 @@ export class UserRepository {
         sumScore,
         fishingRodLevel,
         caughtFish,
+        achievements,
       });
       const savedUser = await newUser.save();
 
@@ -37,6 +46,7 @@ export class UserRepository {
         userId: savedUser.userId,
         fishingRodLevel: savedUser.fishingRodLevel,
         caughtFish: savedUser.caughtFish,
+        achievements: savedUser.achievements,
       };
     } catch (err) {
       console.error("ユーザー作成エラー:", err);
@@ -57,16 +67,24 @@ export class UserRepository {
         throw new Error("ユーザーが見つかりません");
       }
 
-      user.fishingRodLevel = newLevel;
-
       if (user.sumScore < requiredScore) {
         throw new Error("スコアが不足しています");
       }
+
+      user.fishingRodLevel = newLevel;
       user.sumScore -= requiredScore;
 
       await user.save();
       return user.fishingRodLevel;
     } catch (err) {
+      if (err instanceof Error && err.message === "ユーザーが見つかりません") {
+        throw err;
+      }
+
+      if (err instanceof Error && err.message === "スコアが不足しています") {
+        throw err;
+      }
+
       console.error("ユーザー更新エラー:", err);
       throw new Error("ユーザー情報の更新に失敗しました");
     }

--- a/backend/src/usecase/User/AddSumScoreUseCase.ts
+++ b/backend/src/usecase/User/AddSumScoreUseCase.ts
@@ -25,7 +25,8 @@ export class AddSumScoreUseCase {
       undefined, // パスワード
       user.sumScore,
       undefined, // 釣竿レベル
-      undefined // 捕まえた魚リスト
+      undefined, // 捕まえた魚リスト
+      undefined // 実績
     );
     const updateSumScore = newUser.addScore(additionalScore);
     return await this.userRepository.updateSumScore(

--- a/backend/src/usecase/User/RegisterUserUseCase.ts
+++ b/backend/src/usecase/User/RegisterUserUseCase.ts
@@ -26,7 +26,8 @@ export class RegisterUserUseCase {
       newUser.getUser().password,
       newUser.getUser().sumScore,
       newUser.getUser().fishingRodLevel,
-      newUser.getUser().caughtFish
+      newUser.getUser().caughtFish,
+      newUser.getUser().achievements
     );
     return {
       username: savedUser.username,

--- a/backend/src/usecase/User/UpdateFishingRodLevelUseCase.ts
+++ b/backend/src/usecase/User/UpdateFishingRodLevelUseCase.ts
@@ -26,7 +26,7 @@ export class UpdateFishingRodLevelUseCase {
       undefined, // パスワード
       undefined, // 合計スコア
       user.fishingRodLevel,
-      undefined // 捕まえた魚
+      undefined // 捕まえた魚リスト
     );
     const updatableFishingRodLevel =
       newUser.isBigInputFishingRodLevel(fishingRodLevel);


### PR DESCRIPTION
## 内容

■ ユーザーモデルに"実績"を追加しました

■ 釣竿レベル更新のエラー文を場合分けしました
　・ユーザーが見つからない場合と必要なスコアが足らない場合