### PR TITLE
魚APIのプレゼンテーション層

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -11,7 +11,12 @@ import { GetUserDataController } from "@/src/presentation/User/GetUserDataContro
 import { IncrementCaughtFishCountController } from "@/src/presentation/User/IncrementCaughtFishCountController";
 import { RegisterUserController } from "@/src/presentation/User/RegisterUserController";
 import { UpdateFishingRodLevelController } from "@/src/presentation/User/UpdateFishingRodLevelController";
-import { IUserRepository } from "./src/domain/User/User";
+
+import { FishRepository } from "@/src/infrastructure/Fish/FishRepository";
+import { CaughtFishController } from "@/src/presentation/Fish/CatchFishController";
+import { CreatePreFishController } from "@/src/presentation/Fish/CreatePreFishController";
+import { IUserRepository } from "@/src/domain/User/User";
+import { IFishRepository } from "@/src/domain/Fish/Fish";
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -22,6 +27,7 @@ app.use(express.json());
 
 // インフラ層のリポジトリをインスタンス化
 const userRepository: IUserRepository = new UserRepository();
+const fishRepository: IFishRepository = new FishRepository();
 
 // プレゼンテーション層のコントローラをインスタンス化
 const addSumScoreController = new AddSumScoreController(userRepository);
@@ -33,12 +39,24 @@ const updateFishingRodLevelController = new UpdateFishingRodLevelController(
   userRepository
 );
 
+const createFishController = new CreatePreFishController(
+  fishRepository,
+  userRepository
+);
+const catchFishController = new CaughtFishController(
+  fishRepository,
+  userRepository
+);
+
 // エンドポイントを登録
 addSumScoreController.addSumScore(app);
 getUserDataController.getUserData(app);
 incrementCaughtFishCountController.incrementCaughtFishCount(app);
 registerUserController.registerUser(app);
 updateFishingRodLevelController.updateFishingRodLevel(app);
+
+createFishController.createPreFish(app);
+catchFishController.caughtFish(app);
 
 connectDB()
   .then(() => {

--- a/backend/src/presentation/Fish/CatchFishController.ts
+++ b/backend/src/presentation/Fish/CatchFishController.ts
@@ -1,0 +1,38 @@
+import { Router, Request, Response } from "express";
+import { CaughtFishUseCase } from "@/src/usecase/Fish/CatchFishUseCase";
+import { IFishRepository } from "@/src/domain/Fish/Fish";
+import { IUserRepository } from "@/src/domain/User/User";
+
+export class CaughtFishController {
+  private caughtFishUseCase: CaughtFishUseCase;
+
+  constructor(
+    fishRepository: IFishRepository,
+    userRepository: IUserRepository
+  ) {
+    this.caughtFishUseCase = new CaughtFishUseCase(
+      fishRepository,
+      userRepository
+    );
+  }
+  public caughtFish(router: Router) {
+    router.post(
+      "/catch-fish/:userId",
+      async (req: Request, res: Response): Promise<void> => {
+        try {
+          const { userId } = req.params;
+          const { randomId } = req.body;
+          if (!userId || !randomId) {
+            res.status(400).json({ message: "userId と fish が必要です。" });
+            return;
+          }
+          await this.caughtFishUseCase.execute(userId, randomId);
+
+          res.status(200).json({ message: "魚を捕まえました！" });
+        } catch (error: any) {
+          res.status(400).json({ message: error.message });
+        }
+      }
+    );
+  }
+}

--- a/backend/src/presentation/Fish/CreatePreFishController.ts
+++ b/backend/src/presentation/Fish/CreatePreFishController.ts
@@ -1,0 +1,37 @@
+import { Router, Request, Response } from "express";
+import { CreatePreFishUseCase } from "@/src/usecase/Fish/CreatePreFishUseCase";
+import { IFishRepository } from "@/src/domain/Fish/Fish";
+import { IUserRepository } from "@/src/domain/User/User";
+
+export class CreatePreFishController {
+  private createPreFishUseCase: CreatePreFishUseCase;
+
+  constructor(
+    fishRepository: IFishRepository,
+    userRepository: IUserRepository
+  ) {
+    this.createPreFishUseCase = new CreatePreFishUseCase(
+      fishRepository,
+      userRepository
+    );
+  }
+
+  public createPreFish(router: Router) {
+    router.post("/get-fish/:userId", async (req: Request, res: Response) => {
+      try {
+        const { userId } = req.params;
+        const { depth } = req.body;
+        if (!userId) {
+          throw new Error("User ID is required");
+        }
+        if (!userId) {
+          throw new Error("Depth is required");
+        }
+        const result = await this.createPreFishUseCase.execute(userId, depth);
+        res.status(200).json(result);
+      } catch (error: any) {
+        res.status(400).json({ message: error.message });
+      }
+    });
+  }
+}


### PR DESCRIPTION
## 内容

■ 各魚APIのプレゼンテーション層を実装しました

■ index.tsに各魚APIのエンドポイントを登録しました

## 動作確認

■ get-fishのリクエストを送ると深さに対応した釣られる前の魚がレスポンスされ、DBにも釣れる前の魚が保存されることを確認しました

■ catch-fishのリクエストを送ると、ランダムIDに対応した魚をDBに保存し、スコアも加算されることを確認しました

## 問題

■ 20秒以内にget-fishのリクエストを送るとコンソールログにエラーメッセージが表示されるものの、釣れる前の魚を取得できてしまいます