### PR TITLE
魚APIの修正

### DIFF
--- a/backend/src/domain/Fish/Fish.ts
+++ b/backend/src/domain/Fish/Fish.ts
@@ -120,4 +120,12 @@ export interface IFishRepository {
    * @throws ランダムIDに関連するデータが見つからない場合、エラーが発生します。
    */
   isRandomIdInvalid(randomId: string): Promise<boolean>;
+  /**
+   * 指定したユーザーIDの最新のPreFish以外を削除します。
+   *
+   * @param userId 古いPreFishを削除する対象のユーザーID
+   * @returns なし
+   * @throws PreFish情報が見つからない場合、または削除処理中にエラーが発生した場合、エラーをスローします。
+   */
+  deleteOldPreFishByUserId(userId: string): Promise<void>;
 }

--- a/backend/src/infrastructure/Fish/FishRepository.ts
+++ b/backend/src/infrastructure/Fish/FishRepository.ts
@@ -110,4 +110,29 @@ export class FishRepository {
       throw new Error("ランダムIDの無効化状態確認に失敗しました");
     }
   };
+
+  // userIdで指定した最新のPreFish以外を削除する
+  public deleteOldPreFishByUserId = async (userId: string): Promise<void> => {
+    try {
+      const latestPreFish = await PreFishModel.findOne({ userId })
+        .sort({ createdAt: -1 })
+        .select("createdAt");
+
+      if (!latestPreFish) {
+        console.log(`ユーザーID ${userId} のPreFish情報が見つかりません`);
+        return;
+      }
+      const deleteResult = await PreFishModel.deleteMany({
+        userId,
+        createdAt: { $lt: latestPreFish.createdAt },
+      });
+
+      console.log(
+        `ユーザーID ${userId} の古いPreFish ${deleteResult.deletedCount} 件を削除しました`
+      );
+    } catch (err) {
+      console.error(`ユーザーID ${userId} の古いPreFish削除エラー:`, err);
+      throw new Error("古いPreFishの削除に失敗しました");
+    }
+  };
 }

--- a/backend/src/presentation/Fish/CatchFishController.ts
+++ b/backend/src/presentation/Fish/CatchFishController.ts
@@ -26,9 +26,9 @@ export class CaughtFishController {
             res.status(400).json({ message: "userId と fish が必要です。" });
             return;
           }
-          await this.caughtFishUseCase.execute(userId, randomId);
+          const result = await this.caughtFishUseCase.execute(userId, randomId);
 
-          res.status(200).json({ message: "魚を捕まえました！" });
+          res.status(200).json(result);
         } catch (error: any) {
           res.status(400).json({ message: error.message });
         }

--- a/backend/src/usecase/Fish/CatchFishUseCase.ts
+++ b/backend/src/usecase/Fish/CatchFishUseCase.ts
@@ -57,5 +57,11 @@ export class CaughtFishUseCase {
     console.log(
       `ユーザー ${userId} が魚 ${latestPreFish.fish.name} を捕まえました。スコア: ${fishScore}`
     );
+    return {
+      fish: {
+        name: latestPreFish.fish.name,
+        score: latestPreFish.fish.score,
+      },
+    };
   }
 }

--- a/backend/src/usecase/Fish/CreatePreFishUseCase.ts
+++ b/backend/src/usecase/Fish/CreatePreFishUseCase.ts
@@ -32,8 +32,10 @@ export class CreatePreFishUseCase {
       } catch (error: unknown) {
         if (error instanceof Error) {
           console.error("エラー:", error.message);
+          throw error;
         } else {
           console.error("予期しないエラー:", error);
+          throw error;
         }
       }
     }
@@ -53,12 +55,10 @@ export class CreatePreFishUseCase {
       randomId,
       userId
     );
-
+    await this.fishRepository.deleteOldPreFishByUserId(userId);
     FishInterface.requiredInteractions = saveRequiredInteractions;
-
     return {
       fish: savedFish.fish,
-      userId: savedFish.userId,
       randomId: savedFish.randomId,
     };
   }


### PR DESCRIPTION
## 内容

■ get-fishをリクエストを送ったとき、古い釣られる前の魚を削除するように修正しました

■ 魚を捕まえたとき、ユーザーに魚の名前とスコアを返すように修正しました

## 動作確認

■ 20秒以内のget-fishリクエストには、釣られる前の魚をDBに保存せずに、エラーメッセージが返されることを確認しました