### PR TITLE
ポーカーAPIのユースケース層

### DIFF
--- a/backend/src/domain/User/User.ts
+++ b/backend/src/domain/User/User.ts
@@ -68,6 +68,11 @@ export class User {
     this.sumScore += score;
     return this.sumScore;
   }
+  // スコアを減算
+  public subtractScore(score: number): number {
+    this.sumScore -= score;
+    return this.sumScore;
+  }
   // 釣竿レベル更新のためのバリデーションチェック（返り値は更新後のレベルと必要なスコア）
   public validateFishingRodLevelUpgrade(
     input: number

--- a/backend/src/usecase/Poker/ChangeAndCalculateHandUseCase.ts
+++ b/backend/src/usecase/Poker/ChangeAndCalculateHandUseCase.ts
@@ -1,0 +1,40 @@
+import { Poker } from "@/src/domain/Poker/Poker";
+import { IPokerRepository } from "@/src/domain/Poker/Poker";
+import { CardInterface } from "@/models/PokerModel";
+
+export class ChangeAndCalculateHandUseCase {
+  private pokerRepository: IPokerRepository;
+
+  constructor(pokerRepository: IPokerRepository) {
+    this.pokerRepository = pokerRepository;
+  }
+
+  public async execute(
+    userId: string,
+    swapIndices: number[]
+  ): Promise<{ hand: CardInterface[]; score: number }> {
+    const gameData = await this.pokerRepository.getGameData(userId);
+    if (!gameData) throw new Error("ゲームデータが存在しません");
+    if (!gameData.pokerFlag) {
+      throw new Error("ポーカー状態ではありません");
+    }
+    const poker = new Poker(gameData.deck);
+    let hand = gameData.hand;
+
+    // 交換するカードがある場合は交換
+    if (swapIndices.length > 0) {
+      hand = poker.swapCards(hand, swapIndices);
+    }
+    const score = poker.calculateScore(hand, gameData.score);
+
+    if (score === 0) {
+    } else {
+      await this.pokerRepository.updatePokerState(userId, false, true);
+    }
+
+    await this.pokerRepository.updateScore(userId, score);
+    await this.pokerRepository.updateDeck(userId, poker.deck);
+
+    return { hand, score };
+  }
+}

--- a/backend/src/usecase/Poker/DealDoubleUpUseCase.ts
+++ b/backend/src/usecase/Poker/DealDoubleUpUseCase.ts
@@ -1,0 +1,67 @@
+import { Poker } from "@/src/domain/Poker/Poker";
+import { IPokerRepository } from "@/src/domain/Poker/Poker";
+import { CardInterface } from "@/models/PokerModel";
+import { IUserRepository } from "@/src/domain/User/User";
+import { User } from "@/src/domain/User/User";
+
+export class DealDoubleUpUseCase {
+  private pokerRepository: IPokerRepository;
+  private userRepository: IUserRepository;
+
+  constructor(
+    pokerRepository: IPokerRepository,
+    userRepository: IUserRepository
+  ) {
+    this.pokerRepository = pokerRepository;
+    this.userRepository = userRepository;
+  }
+
+  public async execute(
+    userId: string,
+    isDoubleUp: boolean
+  ): Promise<{ card?: CardInterface }> {
+    const gameData = await this.pokerRepository.getGameData(userId);
+    if (!gameData) throw new Error("ゲームデータが存在しません");
+    if (!gameData.doubleUpFlag) {
+      throw new Error("ダブルアップ状態ではありません");
+    }
+    if (!isDoubleUp) {
+      // ダブルアップをスキップ
+      await this.pokerRepository.updatePokerState(userId, false, false);
+      const user = await this.userRepository.getUserById(userId);
+      if (!user) {
+        throw new Error(`ユーザーID ${userId} が見つかりません`);
+      }
+      const newUser = new User(
+        undefined,
+        undefined,
+        undefined,
+        user.sumScore,
+        undefined,
+        undefined,
+        undefined
+      );
+      const updateSumScore = newUser.addScore(gameData.score);
+      await this.userRepository.updateSumScore(user.userId, updateSumScore);
+      return {};
+    }
+
+    let doubleUpCard;
+    const poker = new Poker(gameData.deck);
+    if (
+      gameData.doubleUpCard.rank === "None" &&
+      gameData.doubleUpCard.suit === "None"
+    ) {
+      poker.shuffleDeck();
+      doubleUpCard = poker.drawDoubleUpCard();
+    } else {
+      doubleUpCard = gameData.doubleUpCard;
+    }
+
+    if (!doubleUpCard) throw new Error("デッキにカードがありません");
+    await this.pokerRepository.updateDoubleUpCard(userId, doubleUpCard);
+    await this.pokerRepository.updateDeck(userId, poker.deck);
+
+    return { card: doubleUpCard };
+  }
+}

--- a/backend/src/usecase/Poker/DealPokerUseCase.ts
+++ b/backend/src/usecase/Poker/DealPokerUseCase.ts
@@ -1,0 +1,74 @@
+import { Poker } from "@/src/domain/Poker/Poker";
+import { User } from "@/src/domain/User/User";
+import { IPokerRepository } from "@/src/domain/Poker/Poker";
+import { IUserRepository } from "@/src/domain/User/User";
+import { CardInterface } from "@/models/PokerModel";
+
+export class DealPokerUseCase {
+  private pokerRepository: IPokerRepository;
+  private userRepository: IUserRepository;
+  constructor(
+    pokerRepository: IPokerRepository,
+    userRepository: IUserRepository
+  ) {
+    this.pokerRepository = pokerRepository;
+    this.userRepository = userRepository;
+  }
+
+  public async execute(userId: string, bet: number): Promise<CardInterface[]> {
+    if (bet <= 0) {
+      throw new Error("betは1以上である必要があります");
+    }
+    const pokerDomain = new Poker([]);
+    pokerDomain.initializeDeck();
+    const user = await this.userRepository.getUserById(userId);
+
+    if (!user) {
+      throw new Error(`ユーザーID ${userId} が見つかりません`);
+    }
+
+    if (user.sumScore - bet <= 0) {
+      throw new Error("sumScoreより多くベッドすることはできません");
+    }
+
+    const deck: CardInterface[] = pokerDomain.deck; // デッキを生成
+    let gameData = await this.pokerRepository.getGameData(userId);
+
+    const hand = deck.slice(0, 5);
+    if (hand.length !== 5) {
+      throw new Error("デッキに十分なカードがありません");
+    }
+
+    if (gameData) {
+      // 既存データがある場合は初期化データで更新
+      await this.pokerRepository.updateGameData(userId, {
+        deck: deck.slice(5),
+        hand,
+        hasSwapped: false,
+        score: bet,
+        pokerFlag: false,
+        doubleUpFlag: false,
+        doubleUpCard: { suit: "None", rank: "None" },
+        doubleUpSuccessCount: 0,
+      });
+    } else {
+      // 新規作成
+      await this.pokerRepository.createGameData(userId, deck, bet);
+    }
+
+    const newUser = new User(
+      undefined,
+      undefined,
+      undefined,
+      user.sumScore,
+      undefined,
+      undefined,
+      undefined
+    );
+    const updateSumScore = newUser.subtractScore(bet);
+    await this.userRepository.updateSumScore(user.userId, updateSumScore);
+    await this.pokerRepository.updatePokerState(userId, true, false);
+
+    return hand;
+  }
+}

--- a/backend/src/usecase/Poker/JudgeDoubleUpUseCase.ts
+++ b/backend/src/usecase/Poker/JudgeDoubleUpUseCase.ts
@@ -1,0 +1,84 @@
+import { Suit, Rank } from "@/config/types";
+import { Poker } from "@/src/domain/Poker/Poker";
+import { IPokerRepository } from "@/src/domain/Poker/Poker";
+import { CardInterface } from "@/models/PokerModel";
+import { IUserRepository } from "@/src/domain/User/User";
+import { User } from "@/src/domain/User/User";
+
+export class JudgeDoubleUpUseCase {
+  private static readonly MAX_DOUBLE_UP_SUCCESS = 10;
+  constructor(
+    private pokerRepository: IPokerRepository,
+    private userRepository: IUserRepository
+  ) {}
+
+  public async execute(
+    userId: string,
+    guess: "higher" | "lower"
+  ): Promise<{ guessCorrect: boolean; drawnCard: CardInterface }> {
+    const gameData = await this.pokerRepository.getGameData(userId);
+    if (!gameData || !gameData.doubleUpCard) {
+      throw new Error("ダブルアップカードが設定されていません");
+    }
+    if (!gameData.doubleUpFlag) {
+      throw new Error("ダブルアップ状態ではありません");
+    }
+
+    const poker = new Poker(gameData.deck);
+    const drawnCard = poker.drawDoubleUpCard();
+
+    if (!drawnCard) throw new Error("デッキにカードがありません");
+
+    await this.pokerRepository.updateDeck(userId, poker.deck);
+    await this.pokerRepository.updateDoubleUpCard(userId, drawnCard);
+
+    const previousCard = gameData.doubleUpCard;
+    let newScore = gameData.score;
+    let guessCorrect = false;
+
+    if (
+      poker.rankToValue(drawnCard.rank as Rank) !==
+      poker.rankToValue(previousCard.rank as Rank)
+    ) {
+      guessCorrect = poker.compareCardValues(drawnCard, previousCard, guess);
+      newScore = guessCorrect ? gameData.score * 2 : 0;
+    } else {
+      return { guessCorrect: true, drawnCard };
+    }
+
+    if (guessCorrect) {
+      await this.pokerRepository.incrementDoubleUpSuccessCount(userId);
+    } else {
+      await this.pokerRepository.updatePokerState(userId, false, false);
+    }
+
+    if (
+      guessCorrect &&
+      // 10回目の成功
+      gameData.doubleUpSuccessCount + 1 ===
+        JudgeDoubleUpUseCase.MAX_DOUBLE_UP_SUCCESS
+    ) {
+      const user = await this.userRepository.getUserById(userId);
+      if (!user) {
+        throw new Error(`ユーザーID ${userId} が見つかりません`);
+      }
+      const newUser = new User(
+        undefined,
+        undefined,
+        undefined,
+        user.sumScore,
+        undefined,
+        undefined,
+        undefined
+      );
+      // スコアをダブルアップして、保存する
+      const updateSumScore = newUser.addScore(newScore * 2);
+      await this.userRepository.updateSumScore(user.userId, updateSumScore);
+      await this.pokerRepository.updatePokerState(userId, false, false);
+    }
+
+    await this.pokerRepository.updateScore(userId, newScore);
+
+    return { guessCorrect, drawnCard };
+  }
+}


### PR DESCRIPTION
## 内容

■ User.tsのドメイン層にスコアを減算するメソッドを追加しました

■ それぞれのポーカーに関するのユースケース層を実装しました
　・ポーカーのカードを配るユースケース
　・カードを変えて、手札の点数を計算するユースケース
　・ダブルアップをするか選択して、カードを配るユースケース
　・ダブルアップが成功しているか判定するユースケース