### PR TITLE
ポーカーAPIのプレゼンテーション層

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -18,6 +18,13 @@ import { CreatePreFishController } from "@/src/presentation/Fish/CreatePreFishCo
 import { IUserRepository } from "@/src/domain/User/User";
 import { IFishRepository } from "@/src/domain/Fish/Fish";
 
+import { PokerRepository } from "@/src/infrastructure/Poker/PokerRepository";
+import { ChangeAndCalculateHandController } from "@/src/presentation/Poker/ChangeAndCalculateHandController";
+import { DealCardsController } from "@/src/presentation/Poker/DealCardsController";
+import { DealDoubleUpController } from "@/src/presentation/Poker/DealDoubleUpController";
+import { JudgeDoubleUpController } from "@/src/presentation/Poker/JudgeDoubleUpController";
+import { IPokerRepository } from "@/src/domain/Poker/Poker";
+
 const app = express();
 const port = process.env.PORT || 3000;
 
@@ -28,6 +35,7 @@ app.use(express.json());
 // インフラ層のリポジトリをインスタンス化
 const userRepository: IUserRepository = new UserRepository();
 const fishRepository: IFishRepository = new FishRepository();
+const pokerRepository: IPokerRepository = new PokerRepository();
 
 // プレゼンテーション層のコントローラをインスタンス化
 const addSumScoreController = new AddSumScoreController(userRepository);
@@ -48,6 +56,22 @@ const catchFishController = new CaughtFishController(
   userRepository
 );
 
+const calculateHandScoreController = new ChangeAndCalculateHandController(
+  pokerRepository
+);
+const dealCardsController = new DealCardsController(
+  pokerRepository,
+  userRepository
+);
+const dealDoubleUpController = new DealDoubleUpController(
+  pokerRepository,
+  userRepository
+);
+const judgeDoubleUpController = new JudgeDoubleUpController(
+  pokerRepository,
+  userRepository
+);
+
 // エンドポイントを登録
 addSumScoreController.addSumScore(app);
 getUserDataController.getUserData(app);
@@ -57,6 +81,11 @@ updateFishingRodLevelController.updateFishingRodLevel(app);
 
 createFishController.createPreFish(app);
 catchFishController.caughtFish(app);
+
+calculateHandScoreController.changeAndCalculateHand(app);
+dealCardsController.dealCards(app);
+dealDoubleUpController.dealDoubleUp(app);
+judgeDoubleUpController.judgeDoubleUp(app);
 
 connectDB()
   .then(() => {

--- a/backend/src/domain/Poker/Poker.ts
+++ b/backend/src/domain/Poker/Poker.ts
@@ -87,7 +87,6 @@ export class Poker {
     return bet * multiplier;
   }
   public drawDoubleUpCard(): CardInterface | null {
-    console.log("Current Deck:", this.deck);
     return this.deck.length > 0 ? this.deck.pop()! : null;
   }
   public initializeDeck(): void {

--- a/backend/src/presentation/Poker/ChangeAndCalculateHandController.ts
+++ b/backend/src/presentation/Poker/ChangeAndCalculateHandController.ts
@@ -1,0 +1,42 @@
+import { IPokerRepository } from "@/src/domain/Poker/Poker";
+import { Router, Request, Response } from "express";
+import { ChangeAndCalculateHandUseCase } from "@/src/usecase/Poker/ChangeAndCalculateHandUseCase";
+
+export class ChangeAndCalculateHandController {
+  private calculateHandScoreUseCase: ChangeAndCalculateHandUseCase;
+
+  constructor(pokerRepository: IPokerRepository) {
+    this.calculateHandScoreUseCase = new ChangeAndCalculateHandUseCase(
+      pokerRepository
+    );
+  }
+
+  public changeAndCalculateHand(router: Router) {
+    router.post(
+      "/poker/change-calculate/:userId",
+      async (req: Request, res: Response): Promise<void> => {
+        try {
+          const { userId } = req.params;
+          const { swapIndices } = req.body;
+          if (!userId || !swapIndices) {
+            res
+              .status(400)
+              .json({ message: "userId と swapIndices が必要です。" });
+            return;
+          }
+          const result = await this.calculateHandScoreUseCase.execute(
+            userId,
+            swapIndices
+          );
+          res.status(200).json({
+            success: true,
+            message: "手札の得点を計算しました。",
+            POKER_RESULT: result,
+          });
+        } catch (error: any) {
+          res.status(400).json({ message: error.message });
+        }
+      }
+    );
+  }
+}

--- a/backend/src/presentation/Poker/DealCardsController.ts
+++ b/backend/src/presentation/Poker/DealCardsController.ts
@@ -1,0 +1,42 @@
+import { Router, Request, Response } from "express";
+import { IUserRepository } from "@/src/domain/User/User";
+import { DealPokerUseCase } from "@/src/usecase/Poker/DealPokerUseCase";
+import { IPokerRepository } from "@/src/domain/Poker/Poker";
+
+export class DealCardsController {
+  private dealCardsUseCase: DealPokerUseCase;
+
+  constructor(
+    pokerRepository: IPokerRepository,
+    userRepository: IUserRepository
+  ) {
+    this.dealCardsUseCase = new DealPokerUseCase(
+      pokerRepository,
+      userRepository
+    );
+  }
+
+  public dealCards(router: Router) {
+    router.post(
+      "/poker/deal/:userId",
+      async (req: Request, res: Response): Promise<void> => {
+        try {
+          const { userId } = req.params;
+          const { bet } = req.body;
+          if (!userId || !bet) {
+            res.status(400).json({ message: "userId と bet が必要です。" });
+            return;
+          }
+          const result = await this.dealCardsUseCase.execute(userId, bet);
+          res.status(200).json({
+            success: true,
+            message: "カードが配られました。",
+            POKER_DEAL: result,
+          });
+        } catch (error: any) {
+          res.status(400).json({ message: error.message });
+        }
+      }
+    );
+  }
+}

--- a/backend/src/presentation/Poker/DealDoubleUpController.ts
+++ b/backend/src/presentation/Poker/DealDoubleUpController.ts
@@ -1,0 +1,51 @@
+import { IPokerRepository } from "@/src/domain/Poker/Poker";
+import { Router, Request, Response } from "express";
+import { DealDoubleUpUseCase } from "@/src/usecase/Poker/DealDoubleUpUseCase";
+import { IUserRepository } from "@/src/domain/User/User";
+
+export class DealDoubleUpController {
+  private dealDoubleUpUseCase: DealDoubleUpUseCase;
+
+  constructor(
+    pokerRepository: IPokerRepository,
+    userRepository: IUserRepository
+  ) {
+    this.dealDoubleUpUseCase = new DealDoubleUpUseCase(
+      pokerRepository,
+      userRepository
+    );
+  }
+
+  public dealDoubleUp(router: Router) {
+    router.post(
+      "/double-up/deal/:userId",
+      async (req: Request, res: Response): Promise<void> => {
+        try {
+          const { userId } = req.params;
+          const { isDoubleUp } = req.body;
+
+          if (!userId || typeof isDoubleUp !== "boolean") {
+            res
+              .status(400)
+              .json({ message: "userId と isDoubleUp が必要です。" });
+            return;
+          }
+
+          const result = await this.dealDoubleUpUseCase.execute(
+            userId,
+            isDoubleUp
+          );
+          res.status(200).json({
+            success: true,
+            message: isDoubleUp
+              ? "ダブルアップ用のカードを配布しました。"
+              : "ダブルアップをキャンセルしました。",
+            DOUBLEUP_DEAL: result || null,
+          });
+        } catch (error: any) {
+          res.status(400).json({ message: error.message });
+        }
+      }
+    );
+  }
+}

--- a/backend/src/presentation/Poker/JudgeDoubleUpController.ts
+++ b/backend/src/presentation/Poker/JudgeDoubleUpController.ts
@@ -1,0 +1,47 @@
+import { IPokerRepository } from "@/src/domain/Poker/Poker";
+import { Router, Request, Response } from "express";
+import { JudgeDoubleUpUseCase } from "@/src/usecase/Poker/JudgeDoubleUpUseCase";
+import { IUserRepository } from "@/src/domain/User/User";
+
+export class JudgeDoubleUpController {
+  private judgeDoubleUpUseCase: JudgeDoubleUpUseCase;
+
+  constructor(
+    pokerRepository: IPokerRepository,
+    userRepository: IUserRepository
+  ) {
+    this.judgeDoubleUpUseCase = new JudgeDoubleUpUseCase(
+      pokerRepository,
+      userRepository
+    );
+  }
+
+  public judgeDoubleUp(router: Router) {
+    router.post(
+      "/double-up/judge/:userId",
+      async (req: Request, res: Response): Promise<void> => {
+        try {
+          const { userId } = req.params;
+          const { guess } = req.body;
+
+          if (!userId || !guess) {
+            res.status(400).json({ message: "userId と guess が必要です。" });
+            return;
+          }
+
+          const result = await this.judgeDoubleUpUseCase.execute(userId, guess);
+          // 結果と引いたカードをレスポンスに含める
+          res.status(200).json({
+            success: true,
+            message: result.guessCorrect
+              ? "ダブルアップ成功！"
+              : "ダブルアップ失敗。",
+            result: result,
+          });
+        } catch (error: any) {
+          res.status(400).json({ message: error.message });
+        }
+      }
+    );
+  }
+}

--- a/backend/src/usecase/Poker/DealPokerUseCase.ts
+++ b/backend/src/usecase/Poker/DealPokerUseCase.ts
@@ -15,7 +15,10 @@ export class DealPokerUseCase {
     this.userRepository = userRepository;
   }
 
-  public async execute(userId: string, bet: number): Promise<CardInterface[]> {
+  public async execute(
+    userId: string,
+    bet: number
+  ): Promise<{ hand: CardInterface[]; updateSumScore: number }> {
     if (bet <= 0) {
       throw new Error("betは1以上である必要があります");
     }
@@ -69,6 +72,6 @@ export class DealPokerUseCase {
     await this.userRepository.updateSumScore(user.userId, updateSumScore);
     await this.pokerRepository.updatePokerState(userId, true, false);
 
-    return hand;
+    return { hand, updateSumScore };
   }
 }

--- a/backend/src/usecase/Poker/JudgeDoubleUpUseCase.ts
+++ b/backend/src/usecase/Poker/JudgeDoubleUpUseCase.ts
@@ -15,7 +15,11 @@ export class JudgeDoubleUpUseCase {
   public async execute(
     userId: string,
     guess: "higher" | "lower"
-  ): Promise<{ guessCorrect: boolean; drawnCard: CardInterface }> {
+  ): Promise<{
+    guessCorrect: boolean;
+    drawnCard: CardInterface;
+    newScore: number;
+  }> {
     const pokerData = await this.pokerRepository.getPokerData(userId);
     if (!pokerData || !pokerData.doubleUpCard) {
       throw new Error("ダブルアップカードが設定されていません");
@@ -43,7 +47,7 @@ export class JudgeDoubleUpUseCase {
       guessCorrect = poker.compareCardValues(drawnCard, previousCard, guess);
       newScore = guessCorrect ? pokerData.score * 2 : 0;
     } else {
-      return { guessCorrect: true, drawnCard };
+      return { guessCorrect: true, drawnCard, newScore: 0 };
     }
 
     if (guessCorrect) {
@@ -72,13 +76,13 @@ export class JudgeDoubleUpUseCase {
         undefined
       );
       // スコアをダブルアップして、保存する
-      const updateSumScore = newUser.addScore(newScore * 2);
-      await this.userRepository.updateSumScore(user.userId, updateSumScore);
+      newScore = newUser.addScore(newScore * 2);
+      await this.userRepository.updateSumScore(user.userId, newScore);
       await this.pokerRepository.updatePokerState(userId, false, false);
     }
 
     await this.pokerRepository.updateScore(userId, newScore);
 
-    return { guessCorrect, drawnCard };
+    return { guessCorrect, drawnCard, newScore };
   }
 }


### PR DESCRIPTION
## 内容

■ 各ポーカーAPIのプレゼンテーション層を実装しました

■ index.tsに各ポーカーAPIのエンドポイントを登録しました

■ ポーカーユースケース層の返り値を修正しました

## 動作確認

■ ポーカーとダブルアップの結果に応じて、DBに保存されたユーザーのsumScoreが更新されることを確認しました

■ ポーカー中にダブルアップのリクエストが行えないことを確認しました