### PR TITLE
釣る前の魚の作成処理を改善

### DIFF
--- a/backend/models/PreFishModel.ts
+++ b/backend/models/PreFishModel.ts
@@ -7,6 +7,7 @@ export interface IPreFish extends Document {
   randomId: string;
   isInvalid: boolean;
   createdAt: Date;
+  updatedAt: Date;
 }
 
 const IPreFish: Schema<IPreFish> = new mongoose.Schema(

--- a/backend/src/domain/Fish/Fish.ts
+++ b/backend/src/domain/Fish/Fish.ts
@@ -57,20 +57,28 @@ export class Fish {
     return requiredInteractions <= limit;
   }
   public checkTimeDifference(
-    latestCreatedAt: Date | { createdAt: Date },
+    latestCreatedAt: Date | { createdAt: Date; updatedAt: Date },
     waitTime: number
   ): void {
     const now = new Date();
 
+    // createdAt と updatedAt をそれぞれ取得
     const latestDate =
       latestCreatedAt instanceof Date
         ? latestCreatedAt
         : latestCreatedAt.createdAt;
 
-    const timeDifference = now.getTime() - new Date(latestDate).getTime();
+    const latestUpdatedAt =
+      latestCreatedAt instanceof Date
+        ? latestCreatedAt
+        : latestCreatedAt.updatedAt;
 
-    if (timeDifference < waitTime) {
-      throw new Error("前回のリクエストから20秒以上経過していません");
+    const createdAtDifference = now.getTime() - new Date(latestDate).getTime();
+    const updatedAtDifference =
+      now.getTime() - new Date(latestUpdatedAt).getTime();
+
+    if (createdAtDifference < waitTime || updatedAtDifference < waitTime) {
+      throw new Error("前回のリクエストから指定の待機時間が経過していません");
     }
   }
 }
@@ -120,12 +128,14 @@ export interface IFishRepository {
    * @throws ランダムIDに関連するデータが見つからない場合、エラーが発生します。
    */
   isRandomIdInvalid(randomId: string): Promise<boolean>;
-  /**
-   * 指定したユーザーIDの最新のPreFish以外を削除します。
-   *
-   * @param userId 古いPreFishを削除する対象のユーザーID
-   * @returns なし
-   * @throws PreFish情報が見つからない場合、または削除処理中にエラーが発生した場合、エラーをスローします。
-   */
-  deleteOldPreFishByUserId(userId: string): Promise<void>;
+
+  updatePreFish(
+    fish: FishInterface,
+    randomId: string,
+    userId: string
+  ): Promise<{
+    fish: FishInterface;
+    randomId: string;
+    userId: string;
+  }>;
 }

--- a/backend/src/infrastructure/Fish/FishRepository.ts
+++ b/backend/src/infrastructure/Fish/FishRepository.ts
@@ -52,7 +52,7 @@ export class FishRepository {
     try {
       const latestPreFish = await PreFishModel.findOne({ userId })
         .sort({ createdAt: -1 })
-        .select("fish userId randomId isInvalid createdAt")
+        .select("fish userId randomId isInvalid createdAt updatedAt") // updatedAt を追加
         .lean();
 
       if (!latestPreFish) {
@@ -111,28 +111,40 @@ export class FishRepository {
     }
   };
 
-  // userIdで指定した最新のPreFish以外を削除する
-  public deleteOldPreFishByUserId = async (userId: string): Promise<void> => {
+  // PreFishデータの更新
+  public updatePreFish = async (
+    fish: FishInterface,
+    randomId: string,
+    userId: string
+  ): Promise<{
+    fish: FishInterface;
+    randomId: string;
+    userId: string;
+  }> => {
     try {
-      const latestPreFish = await PreFishModel.findOne({ userId })
-        .sort({ createdAt: -1 })
-        .select("createdAt");
-
-      if (!latestPreFish) {
-        console.log(`ユーザーID ${userId} のPreFish情報が見つかりません`);
-        return;
+      const user = await UserModel.findOne({ userId });
+      if (!user) {
+        throw new Error(`ユーザーID ${userId} は存在しません`);
       }
-      const deleteResult = await PreFishModel.deleteMany({
-        userId,
-        createdAt: { $lt: latestPreFish.createdAt },
-      });
 
-      console.log(
-        `ユーザーID ${userId} の古いPreFish ${deleteResult.deletedCount} 件を削除しました`
+      await PreFishModel.updateOne(
+        { userId },
+        {
+          $set: {
+            fish,
+            randomId,
+          },
+        }
       );
-    } catch (err) {
-      console.error(`ユーザーID ${userId} の古いPreFish削除エラー:`, err);
-      throw new Error("古いPreFishの削除に失敗しました");
+
+      return {
+        fish: fish,
+        userId: userId,
+        randomId: randomId,
+      };
+    } catch (error) {
+      console.error("魚の更新エラー:", error);
+      throw new Error("魚のレスポンス更新に失敗しました");
     }
   };
 }


### PR DESCRIPTION
## 内容

■ 釣る前の魚を作成するとき、既にDBに釣る前の魚があるなら、そのデータを更新するように修正しました
　・インフラストラクチャ層に釣る前の魚を更新するメソッドを追加しました

## 動作確認

■ 釣る前の魚が既にある状態でリクエストを送ると、データが更新されることを確認しました

■ 釣る前の魚更新後20秒以内は新たにデータを更新すると、エラーが返されることを確認しました