### PR TITLE
ベットの上限設定と更新後のsumScoreを返す変更

### DIFF
--- a/backend/src/usecase/Poker/DealDoubleUpUseCase.ts
+++ b/backend/src/usecase/Poker/DealDoubleUpUseCase.ts
@@ -19,7 +19,7 @@ export class DealDoubleUpUseCase {
   public async execute(
     userId: string,
     isDoubleUp: boolean
-  ): Promise<{ card?: CardInterface }> {
+  ): Promise<{ card?: CardInterface; updateSumScore?: number }> {
     const pokerData = await this.pokerRepository.getPokerData(userId);
     if (!pokerData) throw new Error("ゲームデータが存在しません");
     if (!pokerData.doubleUpFlag) {
@@ -43,7 +43,7 @@ export class DealDoubleUpUseCase {
       );
       const updateSumScore = newUser.addScore(pokerData.score);
       await this.userRepository.updateSumScore(user.userId, updateSumScore);
-      return {};
+      return { updateSumScore };
     }
 
     let doubleUpCard;

--- a/backend/src/usecase/Poker/DealPokerUseCase.ts
+++ b/backend/src/usecase/Poker/DealPokerUseCase.ts
@@ -22,6 +22,9 @@ export class DealPokerUseCase {
     if (bet <= 0) {
       throw new Error("betは1以上である必要があります");
     }
+    if (bet > 10000) {
+      throw new Error("betは10000以下である必要があります");
+    }
     const pokerDomain = new Poker([]);
     pokerDomain.initializeDeck();
     const user = await this.userRepository.getUserById(userId);

--- a/backend/src/usecase/Poker/JudgeDoubleUpUseCase.ts
+++ b/backend/src/usecase/Poker/JudgeDoubleUpUseCase.ts
@@ -19,6 +19,7 @@ export class JudgeDoubleUpUseCase {
     guessCorrect: boolean;
     drawnCard: CardInterface;
     newScore: number;
+    updateSumScore?: number;
   }> {
     const pokerData = await this.pokerRepository.getPokerData(userId);
     if (!pokerData || !pokerData.doubleUpCard) {
@@ -77,8 +78,12 @@ export class JudgeDoubleUpUseCase {
       );
       // スコアをダブルアップして、保存する
       newScore = newUser.addScore(newScore * 2);
-      await this.userRepository.updateSumScore(user.userId, newScore);
+      const updateSumScore = await this.userRepository.updateSumScore(
+        user.userId,
+        newScore
+      );
       await this.pokerRepository.updatePokerState(userId, false, false);
+      return { guessCorrect, drawnCard, newScore, updateSumScore };
     }
 
     await this.pokerRepository.updateScore(userId, newScore);


### PR DESCRIPTION
## 内容

■ ベットの上限を10000に設定しました

■ DBに保存されたユーザーのsumScoreが更新されたとき、その値をレスポンスとして返すように変更しました