### PR TITLE
魚の更新と捕まえる処理の修正

### DIFF
--- a/backend/src/infrastructure/Fish/FishRepository.ts
+++ b/backend/src/infrastructure/Fish/FishRepository.ts
@@ -132,6 +132,7 @@ export class FishRepository {
         {
           $set: {
             fish,
+            isInvalid: false,
             randomId,
           },
         }

--- a/backend/src/usecase/Fish/CatchFishUseCase.ts
+++ b/backend/src/usecase/Fish/CatchFishUseCase.ts
@@ -1,6 +1,7 @@
 import { IFishRepository } from "@/src/domain/Fish/Fish";
 import { IUserRepository } from "@/src/domain/User/User";
 import { Fish } from "@/src/domain/Fish/Fish";
+import { User } from "@/src/domain/User/User";
 
 export class CaughtFishUseCase {
   private fishRepository: IFishRepository;
@@ -48,11 +49,27 @@ export class CaughtFishUseCase {
       throw new Error("ランダムIDの無効化に失敗したため、処理を中止します");
     }
     const fishScore = latestPreFish.fish.score;
-    await this.userRepository.updateSumScore(userId, fishScore);
+
+    const user = await this.userRepository.getUserById(userId);
+    if (!user) {
+      throw new Error("ユーザーが見つかりません");
+    }
+
     await this.userRepository.incrementCaughtFishCount(
       userId,
       latestPreFish.fish.name
     );
+    const newUser = new User(
+      undefined,
+      undefined,
+      undefined,
+      user.sumScore,
+      undefined,
+      undefined,
+      undefined
+    );
+    const newScore = newUser.addScore(fishScore);
+    await this.userRepository.updateSumScore(userId, newScore);
 
     console.log(
       `ユーザー ${userId} が魚 ${latestPreFish.fish.name} を捕まえました。スコア: ${fishScore}`


### PR DESCRIPTION
## 内容

■ 既存の釣る前の魚を更新する場合、ランダムIDの無効化をfalseに設定するように修正しました

■ 魚を釣ったとき、既存のユーザースコアに釣った魚のスコアを加算して更新するように修正しました