### PR TITLE
ユーザーの実績追加を実装

### DIFF
--- a/backend/constants/AchievementData.ts
+++ b/backend/constants/AchievementData.ts
@@ -1,0 +1,26 @@
+// 魚の種類と数の実績データ
+export const FISH_ACHIEVEMENTS = {
+  TYPES: [
+    { count: 1, name: "魚を1種類捕まえた！" },
+    { count: 15, name: "魚を15種類捕まえた！" },
+    { count: 20, name: "魚を20種類捕まえた！" },
+    { count: 25, name: "魚を25種類捕まえた！" },
+    { count: 30, name: "魚を30種類捕まえた！" },
+  ],
+  COUNTS: [
+    { count: 1, name: "魚を1匹捕まえた！" },
+    { count: 10, name: "魚を10匹捕まえた！" },
+    { count: 100, name: "魚を100匹捕まえた！" },
+    { count: 500, name: "魚を500匹捕まえた！" },
+    { count: 1000, name: "魚を1,000匹捕まえた！" },
+  ],
+};
+
+// ポーカーの実績データ
+export const POKER_ACHIEVEMENTS = [
+  { points: 1000, name: "ポーカーで1000ポイント稼いだ！" },
+  { points: 10000, name: "ポーカーで10,000ポイント稼いだ！" },
+  { points: 2500000, name: "ポーカーで2,500,000ポイント稼いだ！" },
+  { points: 10000000, name: "ポーカーで10,000,000ポイント稼いだ！" },
+  { points: 100000000, name: "ポーカーで100,000,000ポイント稼いだ！" },
+];

--- a/backend/src/domain/User/User.ts
+++ b/backend/src/domain/User/User.ts
@@ -207,4 +207,11 @@ export interface IUserRepository {
       count: number;
     }[]
   >;
+
+  addFishingAchievements(
+    userId: string,
+    caughtFish: { name: string; count: number }[]
+  ): Promise<void>;
+
+  addPokerAchievements(userId: string, points: number): Promise<void>;
 }

--- a/backend/src/usecase/Fish/CatchFishUseCase.ts
+++ b/backend/src/usecase/Fish/CatchFishUseCase.ts
@@ -68,6 +68,9 @@ export class CaughtFishUseCase {
       undefined,
       undefined
     );
+
+    const caughtFish = user.caughtFish;
+    await this.userRepository.addFishingAchievements(userId, caughtFish);
     const newScore = newUser.addScore(fishScore);
     await this.userRepository.updateSumScore(userId, newScore);
 

--- a/backend/src/usecase/Poker/DealDoubleUpUseCase.ts
+++ b/backend/src/usecase/Poker/DealDoubleUpUseCase.ts
@@ -43,6 +43,7 @@ export class DealDoubleUpUseCase {
       );
       const updateSumScore = newUser.addScore(pokerData.score);
       await this.userRepository.updateSumScore(user.userId, updateSumScore);
+      await this.userRepository.addPokerAchievements(userId, pokerData.score);
       return { updateSumScore };
     }
 

--- a/backend/src/usecase/Poker/JudgeDoubleUpUseCase.ts
+++ b/backend/src/usecase/Poker/JudgeDoubleUpUseCase.ts
@@ -1,4 +1,4 @@
-import { Suit, Rank } from "@/config/types";
+import { Rank } from "@/config/types";
 import { Poker } from "@/src/domain/Poker/Poker";
 import { IPokerRepository } from "@/src/domain/Poker/Poker";
 import { CardInterface } from "@/models/PokerModel";
@@ -82,6 +82,7 @@ export class JudgeDoubleUpUseCase {
         user.userId,
         newScore
       );
+      await this.userRepository.addPokerAchievements(userId, newScore);
       await this.pokerRepository.updatePokerState(userId, false, false);
       return { guessCorrect, drawnCard, newScore, updateSumScore };
     }


### PR DESCRIPTION
## 内容

■ ユーザーが条件を満たしたとき、DBのユーザーデータに実績を追加するようにしました

## 動作確認

■ 条件を満たしたとき、魚とポーカーの実績を獲得できることを確認しました