### PR TITLE
ポーカーAPIの改善

### DIFF
--- a/backend/src/domain/Poker/Poker.ts
+++ b/backend/src/domain/Poker/Poker.ts
@@ -5,14 +5,13 @@ import { IPokerGame } from "@/models/PokerModel";
 export class Poker {
   HAND_SIZE = 5;
   PAYOUT_MULTIPLIERS: Record<string, number> = {
-    "Straight Flush": 50,
-    "Four of a Kind": 25,
-    "Full House": 10,
-    Flush: 8,
-    Straight: 5,
-    "Three of a Kind": 3,
-    "Two Pair": 2,
-    "One Pair": 1,
+    "Straight Flush": 20,
+    "Four of a Kind": 10,
+    "Full House": 5,
+    Flush: 4,
+    Straight: 2,
+    "Three of a Kind": 1,
+    "Two Pair": 1,
     "High Card": 0,
   };
 
@@ -49,7 +48,6 @@ export class Poker {
     if (Object.values(rankCounts).includes(3)) return "Three of a Kind";
     if (Object.values(rankCounts).filter((count) => count === 2).length === 2)
       return "Two Pair";
-    if (Object.values(rankCounts).includes(2)) return "One Pair";
     return "High Card";
   }
 

--- a/backend/src/usecase/Poker/JudgeDoubleUpUseCase.ts
+++ b/backend/src/usecase/Poker/JudgeDoubleUpUseCase.ts
@@ -48,7 +48,7 @@ export class JudgeDoubleUpUseCase {
       guessCorrect = poker.compareCardValues(drawnCard, previousCard, guess);
       newScore = guessCorrect ? pokerData.score * 2 : 0;
     } else {
-      return { guessCorrect: true, drawnCard, newScore: 0 };
+      return { guessCorrect: true, drawnCard, newScore: pokerData.score };
     }
 
     if (guessCorrect) {


### PR DESCRIPTION
## 内容

■ ポーカーで役ができたときの倍率を修正

■ ダブルアップで同じ数字を引いたとき、スコアをそのまま返すように改善