### PR TITLE
図鑑ページの実装

### DIFF
--- a/frontend/components/container/illustratedBook/Achievement.vue
+++ b/frontend/components/container/illustratedBook/Achievement.vue
@@ -1,0 +1,153 @@
+<template>
+  <div class="achievement-container">
+    <div class="achievements">
+      <div
+        class="achievement-group"
+        v-for="group in achievementGroups"
+        :key="group.level"
+      >
+        <div class="fish-icons">
+          <div
+            v-for="(achievement, index) in group.achievements"
+            :key="index"
+            class="achievement-item"
+          >
+            <MoleculesFishIconTooltip
+              v-if="achievement.group === '1' || achievement.group === '2'"
+              :tooltipText="achievement.name"
+              :color="getAchievementColor(achievement.name)"
+              :size="'15rem'"
+            />
+            <MoleculesCardIconTooltip
+              v-if="achievement.group === '3'"
+              :tooltipText="achievement.name"
+              :color="getAchievementColor(achievement.name)"
+              :size="'12rem'"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import "@/assets/scss/main.scss";
+import { useUserStore } from "@/store/user";
+const userStore = useUserStore();
+
+const getAchievementColor = (achievementName: string) => {
+  const allAchievements = getAchievements();
+
+  for (const group of allAchievements) {
+    const achievement = group.achievements.find(
+      (achievement) => achievement.name === achievementName
+    );
+    if (achievement) {
+      const userAchievement = userStore.achievements?.find(
+        (userAch) => userAch.name === achievementName
+      );
+
+      if (userAchievement) {
+        return achievement.color;
+      } else {
+        return "gray";
+      }
+    }
+  }
+  return "gray";
+};
+
+const getAchievements = () => {
+  return [
+    {
+      level: 5,
+      achievements: [
+        { name: "魚を30種類捕まえた！", color: "gold", group: "1" },
+        { name: "魚を1,000匹捕まえた！", color: "gold", group: "2" },
+        {
+          name: "ポーカーで100,000,000ポイント稼いだ！",
+          color: "gold",
+          group: "3",
+        },
+      ],
+    },
+    {
+      level: 4,
+      achievements: [
+        { name: "魚を25種類捕まえた！", color: "silver", group: "1" },
+        { name: "魚を500匹捕まえた！", color: "silver", group: "2" },
+        {
+          name: "ポーカーで10,000,000ポイント稼いだ！",
+          color: "silver",
+          group: "3",
+        },
+      ],
+    },
+    {
+      level: 3,
+      achievements: [
+        { name: "魚を20種類捕まえた！", color: "bronze", group: "1" },
+        { name: "魚を100匹捕まえた！", color: "bronze", group: "2" },
+        {
+          name: "ポーカーで2,500,000ポイント稼いだ！",
+          color: "bronze",
+          group: "3",
+        },
+      ],
+    },
+    {
+      level: 2,
+      achievements: [
+        { name: "魚を15種類捕まえた！", color: "purple", group: "1" },
+        { name: "魚を10匹捕まえた！", color: "purple", group: "2" },
+        {
+          name: "ポーカーで10,000ポイント稼いだ！",
+          color: "purple",
+          group: "3",
+        },
+      ],
+    },
+    {
+      level: 1,
+      achievements: [
+        { name: "魚を1種類捕まえた！", color: "blue", group: "1" },
+        { name: "魚を1匹捕まえた！", color: "blue", group: "2" },
+        { name: "ポーカーで1000ポイント稼いだ！", color: "blue", group: "3" },
+      ],
+    },
+  ];
+};
+
+const achievementGroups = getAchievements();
+</script>
+
+<style scoped lang="scss">
+.achievement-container {
+  text-align: center;
+  min-height: 85vh;
+  text-align: center;
+  background: $yellow-30;
+  border: 2px solid $yellow-70;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.2);
+}
+
+.achievement-group {
+  margin-bottom: 20px;
+}
+
+.fish-icons {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.achievement-item {
+  flex: 1 1 30%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+</style>

--- a/frontend/components/container/illustratedBook/Fish.vue
+++ b/frontend/components/container/illustratedBook/Fish.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="fish-book">
+    <div class="fish-list">
+      <AtomsCard
+        v-for="fish in fishList"
+        :key="fish.name"
+        :variant="getVariant(fish.score)"
+        size="small"
+        hoverEffect
+      >
+        <template #image>
+          <img
+            :src="getFishImage(fish.name)"
+            :alt="isCaught(fish.name) ? fish.name : '???'"
+            :class="{ img: true, silhouette: !isCaught(fish.name) }"
+          />
+        </template>
+        <template #title>
+          <h3>
+            {{ isCaught(fish.name) || fish.score < 250 ? fish.name : "???" }}
+          </h3>
+        </template>
+        <template #description>
+          <p>スコア: {{ fish.score }}</p>
+          <p>
+            捕獲可能範囲: {{ fish.CatchableMinDepth }}m 〜
+            {{ fish.CatchableMaxDepth }}m
+          </p>
+        </template>
+      </AtomsCard>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import "@/assets/scss/main.scss";
+import { useUserStore } from "@/store/user";
+import { fishList } from "@/constants/FishData";
+import { FishImages } from "@/constants/FishImages";
+
+const userStore = useUserStore();
+
+// 捕まえた魚の名前リストを取得
+const caughtFishNames = computed(() => {
+  return userStore.getCaughtFishNames();
+});
+
+// 指定した魚が捕まえられたか判定
+const isCaught = (fishName: string): boolean => {
+  return caughtFishNames.value.includes(fishName);
+};
+
+// fishImages の型を Record<string, string> に設定
+const fishImages = FishImages as Record<string, string>;
+
+// 魚の画像を取得する関数
+const getFishImage = (fishName: string): string => {
+  return isCaught(fishName)
+    ? fishImages[fishName]
+    : fishImages["デフォルトの魚"];
+};
+
+const getVariant = (score: number): string => {
+  if (score >= 800) return "gold";
+  if (score >= 450) return "silver";
+  if (score >= 250) return "bronze";
+  return "blue";
+};
+</script>
+
+<style lang="scss" scoped>
+.fish-book {
+  text-align: center;
+  background: $yellow-30;
+  border: 2px solid $yellow-70;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.2);
+}
+
+.fish-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.img {
+  height: 6rem;
+  transition: transform 0.3s ease;
+
+  &:hover {
+    transform: scale(1.05);
+  }
+}
+
+.silhouette {
+  filter: grayscale(100%) brightness(0);
+  opacity: 0.6;
+}
+</style>

--- a/frontend/components/container/illustratedBook/TabLink.vue
+++ b/frontend/components/container/illustratedBook/TabLink.vue
@@ -1,0 +1,37 @@
+<template>
+  <button @click="$emit('click')" :class="{ active: isActive }">
+    {{ tab.label }}
+  </button>
+</template>
+
+<script setup lang="ts">
+import type { Tab } from "@/types/type";
+const props = defineProps<{
+  currentTab: string;
+  tab: Tab;
+}>();
+
+defineEmits<{
+  click: [];
+}>();
+
+const isActive = computed(() => props.currentTab === props.tab.key);
+</script>
+
+<style scoped lang="scss">
+button {
+  font-size: 3rem;
+  padding: 3rem;
+
+  &.active {
+    border-bottom-color: #3b82f6;
+    color: #3b82f6;
+  }
+
+  &:focus {
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.5);
+  }
+
+  transition: all 0.3s ease;
+}
+</style>

--- a/frontend/components/presentational/Atoms/Card.vue
+++ b/frontend/components/presentational/Atoms/Card.vue
@@ -20,7 +20,15 @@ const props = defineProps({
     type: String,
     default: "default",
     validator: (value: string) =>
-      ["default", "primary", "secondary"].includes(value),
+      [
+        "default",
+        "primary",
+        "secondary",
+        "gold",
+        "silver",
+        "bronze",
+        "blue",
+      ].includes(value),
   },
   size: {
     type: String,
@@ -62,6 +70,39 @@ const computedClass = computed(() => {
   }
   &--secondary {
     background-color: $orange-40;
+  }
+  &--gold {
+    background: linear-gradient(
+      45deg,
+      #b67b03 0%,
+      #daaf08 45%,
+      #fee9a0 70%,
+      #daaf08 85%,
+      #b67b03 90% 100%
+    );
+  }
+  &--silver {
+    background: linear-gradient(
+      45deg,
+      #757575 0%,
+      #9e9e9e 45%,
+      #e8e8e8 70%,
+      #9e9e9e 85%,
+      #757575 90% 100%
+    );
+  }
+  &--bronze {
+    background: linear-gradient(
+      45deg,
+      #b87333 0%,
+      #d1885e 45%,
+      #f0c07b 70%,
+      #d1885e 85%,
+      #b87333 90% 100%
+    );
+  }
+  &--blue {
+    background-color: $skyblue-20;
   }
 }
 

--- a/frontend/components/presentational/Atoms/CardIcon.vue
+++ b/frontend/components/presentational/Atoms/CardIcon.vue
@@ -13,6 +13,10 @@ export default {
         );
       },
     },
+    size: {
+      type: String,
+      default: "5rem",
+    },
   },
   computed: {
     cardStyle() {
@@ -45,6 +49,8 @@ export default {
       }
       return {
         background,
+        width: this.size,
+        height: this.size,
       };
     },
   },
@@ -53,9 +59,6 @@ export default {
 
 <style lang="scss" scoped>
 .card {
-  width: 5rem;
-  height: 5rem;
-
   -webkit-mask-image: url("@/assets/images/tools/card.png");
   -webkit-mask-size: contain;
   -webkit-mask-repeat: no-repeat;

--- a/frontend/components/presentational/Atoms/FishIcon.vue
+++ b/frontend/components/presentational/Atoms/FishIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fish" :style="cardStyle"></div>
+  <div class="fish" :style="fishStyle"></div>
 </template>
 
 <script>
@@ -13,9 +13,13 @@ export default {
         );
       },
     },
+    size: {
+      type: String,
+      default: "7rem",
+    },
   },
   computed: {
-    cardStyle() {
+    fishStyle() {
       let background;
       switch (this.color) {
         case "gold":
@@ -45,6 +49,8 @@ export default {
       }
       return {
         background,
+        width: this.size,
+        height: this.size,
       };
     },
   },
@@ -53,9 +59,6 @@ export default {
 
 <style lang="scss" scoped>
 .fish {
-  width: 7rem;
-  height: 7rem;
-
   -webkit-mask-image: url("@/assets/images/tools/suzuki.png");
   -webkit-mask-size: contain;
   -webkit-mask-repeat: no-repeat;

--- a/frontend/components/presentational/Atoms/Tooltip.vue
+++ b/frontend/components/presentational/Atoms/Tooltip.vue
@@ -44,7 +44,7 @@ import "@/assets/scss/main.scss";
   &:before {
     content: "";
     position: absolute;
-    top: -13px;
+    top: -11px;
     left: 50%;
     margin-left: -7px;
     border: 7px solid transparent;

--- a/frontend/components/presentational/Atoms/UserProfile.vue
+++ b/frontend/components/presentational/Atoms/UserProfile.vue
@@ -24,77 +24,15 @@
 <script setup lang="ts">
 import "@/assets/scss/main.scss";
 import { useUserStore } from "@/store/user";
-import {
-  アジ,
-  ブリ,
-  クリオネ,
-  ダイオウグソクムシ,
-  ダンクルオステウス,
-  フグ,
-  ヒラメ,
-  イカ,
-  伊勢海老,
-  イワシ,
-  クラゲ,
-  海草,
-  カジキ,
-  カツオ,
-  キンメダイ,
-  マグロ,
-  マンボウ,
-  メンダコ,
-  リュウグウノツカイ,
-  サメ,
-  サケ,
-  サンマ,
-  スズキ,
-  タイ,
-  タコ,
-  トビウオ,
-  ウミガメ,
-  ウナギ,
-  ウツボ,
-  ザトウクジラ,
-  デフォルトの魚,
-} from "@/constants/FishImages";
+import { FishImages } from "@/constants/FishImages";
+import type { FishImageKeys } from "@/constants/FishImages"; // FishImages と FishImageKeys をインポート
 
 const userStore = useUserStore();
 const isDataLoaded = ref(false);
 const highScoreFish = ref<{ name: string; score: number } | null>(null);
 
-const fishImages: Record<string, string> = {
-  アジ,
-  ブリ,
-  クリオネ,
-  ダイオウグソクムシ,
-  ダンクルオステウス,
-  フグ,
-  ヒラメ,
-  イカ,
-  伊勢海老,
-  イワシ,
-  クラゲ,
-  海草,
-  カジキ,
-  カツオ,
-  キンメダイ,
-  マグロ,
-  マンボウ,
-  メンダコ,
-  リュウグウノツカイ,
-  サメ,
-  サケ,
-  サンマ,
-  スズキ,
-  タイ,
-  タコ,
-  トビウオ,
-  ウミガメ,
-  ウナギ,
-  ウツボ,
-  ザトウクジラ,
-  デフォルトの魚,
-};
+// FishImages から画像マッピングを作成
+const fishImages: Record<FishImageKeys, string> = FishImages;
 
 onMounted(async () => {
   const result = await userStore.getUserData();
@@ -103,11 +41,9 @@ onMounted(async () => {
     console.error(result.message);
   } else {
     const highestScoringFish = userStore.highScoreFish;
-    if (highestScoringFish) {
-      highScoreFish.value = highestScoringFish;
-    } else {
-      highScoreFish.value = { name: "デフォルトの魚", score: 0 };
-    }
+    highScoreFish.value = highestScoringFish
+      ? highestScoringFish
+      : { name: "デフォルトの魚", score: 0 };
   }
   isDataLoaded.value = true;
 });
@@ -120,9 +56,11 @@ watch(
   }
 );
 
+// 魚の画像を取得
 const highScoreFishImage = computed(() => {
   const fishName = highScoreFish.value?.name || "デフォルトの魚";
-  return fishImages[fishName] || fishImages["デフォルトの魚"];
+  // FishImages から画像を取得
+  return fishImages[fishName as FishImageKeys] || fishImages["デフォルトの魚"];
 });
 </script>
 

--- a/frontend/components/presentational/Molecules/CardIconTooltip.vue
+++ b/frontend/components/presentational/Molecules/CardIconTooltip.vue
@@ -1,7 +1,7 @@
 <template>
   <AtomsTooltip>
     <template #target>
-      <AtomsCardIcon :color="color"></AtomsCardIcon>
+      <AtomsCardIcon :color="color" :size="size"></AtomsCardIcon>
     </template>
     <template #text>{{ tooltipText }}</template>
   </AtomsTooltip>
@@ -17,6 +17,10 @@ export default defineComponent({
     color: {
       type: String,
       required: true,
+    },
+    size: {
+      type: String,
+      default: "5rem",
     },
   },
 });

--- a/frontend/components/presentational/Molecules/FishIconTooltip.vue
+++ b/frontend/components/presentational/Molecules/FishIconTooltip.vue
@@ -1,7 +1,7 @@
 <template>
   <AtomsTooltip>
     <template #target>
-      <AtomsFishIcon :color="color"></AtomsFishIcon>
+      <AtomsFishIcon :color="color" :size="size"></AtomsFishIcon>
     </template>
     <template #text>{{ tooltipText }}</template>
   </AtomsTooltip>
@@ -18,8 +18,10 @@ export default defineComponent({
       type: String,
       required: true,
     },
+    size: {
+      type: String,
+      default: "7rem",
+    },
   },
 });
 </script>
-
-<style scoped lang="scss"></style>

--- a/frontend/constants/FishData.ts
+++ b/frontend/constants/FishData.ts
@@ -1,9 +1,25 @@
 export const fishList = [
   {
+    name: "海草",
+    score: 50,
+    frequency: 50,
+    requiredInteractions: 10,
+    CatchableMinDepth: 0,
+    CatchableMaxDepth: 100,
+  },
+  {
     name: "イワシ",
     score: 60,
     frequency: 60,
     requiredInteractions: 5,
+    CatchableMinDepth: 0,
+    CatchableMaxDepth: 3,
+  },
+  {
+    name: "タコ",
+    score: 98,
+    frequency: 98,
+    requiredInteractions: 25,
     CatchableMinDepth: 0,
     CatchableMaxDepth: 3,
   },
@@ -47,14 +63,7 @@ export const fishList = [
     CatchableMinDepth: 10,
     CatchableMaxDepth: 20,
   },
-  {
-    name: "タコ",
-    score: 98,
-    frequency: 98,
-    requiredInteractions: 25,
-    CatchableMinDepth: 0,
-    CatchableMaxDepth: 3,
-  },
+
   {
     name: "ウナギ",
     score: 137,
@@ -159,14 +168,7 @@ export const fishList = [
     CatchableMinDepth: 10,
     CatchableMaxDepth: 15,
   },
-  {
-    name: "キンメダイ",
-    score: 270,
-    frequency: 270,
-    requiredInteractions: 25,
-    CatchableMinDepth: 20,
-    CatchableMaxDepth: 80,
-  },
+
   {
     name: "サメ",
     score: 150,
@@ -183,14 +185,7 @@ export const fishList = [
     CatchableMinDepth: 6,
     CatchableMaxDepth: 14,
   },
-  {
-    name: "海草",
-    score: 50,
-    frequency: 50,
-    requiredInteractions: 10,
-    CatchableMinDepth: 0,
-    CatchableMaxDepth: 100,
-  },
+
   {
     name: "伊勢海老",
     score: 250,
@@ -198,6 +193,14 @@ export const fishList = [
     requiredInteractions: 20,
     CatchableMinDepth: 0,
     CatchableMaxDepth: 3,
+  },
+  {
+    name: "キンメダイ",
+    score: 270,
+    frequency: 270,
+    requiredInteractions: 25,
+    CatchableMinDepth: 20,
+    CatchableMaxDepth: 80,
   },
   {
     name: "マンボウ",

--- a/frontend/constants/FishImages.ts
+++ b/frontend/constants/FishImages.ts
@@ -2,7 +2,7 @@ import アジ from "@/assets/images/fish/aji.png";
 import ブリ from "@/assets/images/fish/buri.png";
 import クリオネ from "@/assets/images/fish/clione.png";
 import ダイオウグソクムシ from "@/assets/images/fish/daiougusokumushi.png";
-import ダンクルオステウス from "@/assets/images/fish/daiougusokumushi.png";
+import ダンクルオステウス from "@/assets/images/fish/dunkleosteus.png";
 import フグ from "@/assets/images/fish/fugu.png";
 import ヒラメ from "@/assets/images/fish/hirame.png";
 import イカ from "@/assets/images/fish/ika.png";
@@ -30,7 +30,7 @@ import ウツボ from "@/assets/images/fish/unagi.png";
 import ザトウクジラ from "@/assets/images/fish/zatoukujira.png";
 import デフォルトの魚 from "@/assets/images/fish/default-fish.png";
 
-export {
+export const FishImages = {
   アジ,
   ブリ,
   クリオネ,
@@ -62,4 +62,6 @@ export {
   ウツボ,
   ザトウクジラ,
   デフォルトの魚,
-};
+} as const;
+
+export type FishImageKeys = keyof typeof FishImages;

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -14,6 +14,10 @@ export default defineNuxtConfig({
     { path: "~/components/container/ranking", prefix: "Ranking" },
     { path: "~/components/container/shop", prefix: "Shop" },
     { path: "~/components/container/poker", prefix: "Poker" },
+    {
+      path: "~/components/container/illustratedBook",
+      prefix: "illustratedBook",
+    },
   ],
   css: ["~/assets/scss/main.scss"],
   vite: {

--- a/frontend/pages/illustratedBook.vue
+++ b/frontend/pages/illustratedBook.vue
@@ -1,0 +1,61 @@
+<template>
+  <nav class="tabs-nav">
+    <ul class="tabs-list">
+      <li
+        v-for="tab in tabs"
+        :key="tab.key"
+        class="tab-item"
+        @click="currentTab = tab.key"
+      >
+        <IllustratedBookTabLink :tab="tab" :currentTab="currentTab" />
+      </li>
+    </ul>
+  </nav>
+  <component :is="currentTabComponent" class="tab-content" />
+</template>
+<script setup lang="ts">
+import "@/assets/scss/main.scss";
+import Achievement from "@/components/container/illustratedBook/Achievement.vue";
+import Fish from "@/components/container/illustratedBook/Fish.vue";
+import type { Tab, TabKey } from "@/types/type";
+const tabs: Tab[] = [
+  { key: "図鑑", label: "図鑑", component: Fish },
+  { key: "実績", label: "実績", component: Achievement },
+];
+
+const currentTab = ref<TabKey>("図鑑");
+const currentTabComponent = computed(
+  () => tabs.find((tab) => tab.key === currentTab.value)?.component
+);
+</script>
+
+<style scoped lang="scss">
+.tabs-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 500;
+  text-align: center;
+  padding-bottom: 2rem;
+  background-color: $yellow-20;
+  min-height: 15vh;
+}
+
+.tabs-list {
+  display: flex;
+  justify-content: center;
+  padding: 0;
+  list-style: none;
+}
+
+.tab-item {
+  cursor: pointer;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  border-radius: 0.375rem;
+  margin: 0 0.25rem;
+  transition: all 0.3s ease;
+  color: #4b5563;
+  border: 1px solid transparent;
+}
+</style>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -19,6 +19,9 @@
       class="shop-icon"
     />
   </NuxtLink>
+  <NuxtLink to="/illustratedBook">
+    <img src="@/assets/images/naviIcon/illustratedBook.png" alt="図鑑" />
+  </NuxtLink>
 </template>
 
 <script setup lang="ts"></script>

--- a/frontend/store/user.ts
+++ b/frontend/store/user.ts
@@ -155,6 +155,14 @@ export const useUserStore = defineStore(
         : null;
     };
 
+    // 捕まえた魚の名前を抽出する関数
+    const getCaughtFishNames = () => {
+      if (!caughtFish.value || caughtFish.value.length === 0) return [];
+
+      // 捕まえた魚の名前だけを抽出
+      return caughtFish.value.map((fish) => fish.name);
+    };
+
     return {
       username,
       userId,
@@ -168,6 +176,7 @@ export const useUserStore = defineStore(
       updateFishingRodLevel,
       getUserData,
       updateHighScoreFish,
+      getCaughtFishNames,
     };
   },
   {

--- a/frontend/types/type.ts
+++ b/frontend/types/type.ts
@@ -88,3 +88,11 @@ export interface DoubleUpResultResponse {
   message: string;
   DOUBLEUP_RESULT: DoubleUpResult;
 }
+
+export type TabKey = "図鑑" | "実績";
+
+export interface Tab {
+  key: TabKey;
+  label: string;
+  component: Component;
+}


### PR DESCRIPTION
## 内容

■ 魚の図鑑と実績が確認できる図鑑ページを実装しました
　・実績を表示するコンポーネントを実装しました
　・魚の図鑑を表示するコンポーネントを実装しました
　・魚図鑑と実績のタブ移動を操作するコンポーネントを実装しました

■ 魚の実績ツールチップとポーカーの実績ツールチップを改善しました

■ 魚図鑑表示のために魚の画像パスを修正しました